### PR TITLE
feat: Remove shared user ID from budget and goal management components

### DIFF
--- a/src/features/budgets/hooks/use-budget-form.ts
+++ b/src/features/budgets/hooks/use-budget-form.ts
@@ -10,7 +10,6 @@ import { useRouter } from "next/navigation";
 
 const budgetSchema = z
   .object({
-    shared_user_id: z.coerce.number().optional(),
     category_id: z.coerce
       .number({
         invalid_type_error: "La categoría debe ser un número",
@@ -55,7 +54,6 @@ export const useBudgetForm = ({ budget }: UseBudgetFormProps) => {
   const updateBudget = useUpdateBudget();
 
   const defaultValues: Partial<BudgetForm> = {
-    shared_user_id: budget?.shared_user_id || undefined,
     category_id: budget?.category?.id || undefined,
     current_amount: budget?.current_amount || 0,
     limit_amount: budget?.limit_amount || undefined,

--- a/src/features/budgets/interfaces/budgets.interface.ts
+++ b/src/features/budgets/interfaces/budgets.interface.ts
@@ -1,7 +1,6 @@
 import { Category } from "@/features/categories/interfaces/categories.interface";
 
 export interface BudgetBase {
-  shared_user_id?: number | null;
   limit_amount: number;
   current_amount: number;
   month: Date | string;
@@ -15,7 +14,6 @@ export interface Budget extends BudgetBase {
 
 export interface BudgetCreate {
   user_id: number;
-  shared_user_id?: number | null;
   category_id: number;
   limit_amount: number;
   current_amount?: number;

--- a/src/features/budgets/presentation/components/budget-card.tsx
+++ b/src/features/budgets/presentation/components/budget-card.tsx
@@ -93,12 +93,6 @@ const BudgetCard = ({ budget }: BudgetCardProps) => {
           {progress.toFixed(0)}% utilizado
           {isOverBudget && " (Excedido)"}
         </div>
-
-        {budget.shared_user_id && (
-          <div className="text-sm text-blue-500 mt-2">
-            Presupuesto compartido con otro usuario
-          </div>
-        )}
       </CardContent>
       <CardFooter className="flex flex-wrap justify-end gap-2 pt-0">
         <Button

--- a/src/features/budgets/presentation/components/budget-form.tsx
+++ b/src/features/budgets/presentation/components/budget-form.tsx
@@ -48,12 +48,6 @@ const BudgetForm = ({ budget }: BudgetFormProps) => {
 
         <RHFDatePicker name="month" label="Mes" minDate={new Date()} />
 
-        <RHFInput
-          name="shared_user_id"
-          label="Usuario Compartido (opcional)"
-          type="number"
-        />
-
         <div className="flex space-x-2 mt-6">
           <Button onClick={onCancel} type="button">
             Cancelar

--- a/src/features/goals/hooks/use-goal-form.ts
+++ b/src/features/goals/hooks/use-goal-form.ts
@@ -8,7 +8,6 @@ import { useRouter } from "next/navigation";
 
 const goalSchema = z
   .object({
-    shared_user_id: z.coerce.number().optional(),
     name: z.string().min(1, "El nombre es requerido"),
     current_amount: z.coerce
       .number({
@@ -52,7 +51,6 @@ export const useGoalForm = ({ goal }: UseGoalFormProps) => {
   const form = useForm<GoalForm>({
     resolver: zodResolver(goalSchema),
     defaultValues: {
-      shared_user_id: goal?.shared_user_id || undefined,
       name: goal?.name || "",
       current_amount: goal?.current_amount || 0,
       target_amount: goal?.target_amount || 0,

--- a/src/features/goals/interfaces/ goals.interface.ts
+++ b/src/features/goals/interfaces/ goals.interface.ts
@@ -1,7 +1,6 @@
 import { Category } from "@/features/categories/interfaces/categories.interface";
 
 export interface GoalBase {
-  shared_user_id?: number;
   name: string;
   target_amount: number;
   current_amount: number;

--- a/src/features/goals/presentation/components/goal-card.tsx
+++ b/src/features/goals/presentation/components/goal-card.tsx
@@ -70,12 +70,6 @@ const GoalCard = ({ goal }: GoalCardProps) => {
         <div className="text-right text-sm">
           {progress.toFixed(0)}% completado
         </div>
-
-        {goal.shared_user_id && (
-          <div className="text-sm text-blue-500 mt-2">
-            Meta compartida con otro usuario
-          </div>
-        )}
       </CardContent>
       <CardFooter className="flex flex-wrap justify-end gap-2 pt-0">
         <Button

--- a/src/features/goals/presentation/components/goal-form.tsx
+++ b/src/features/goals/presentation/components/goal-form.tsx
@@ -54,7 +54,6 @@ const GoalForm = ({ goal }: GoalFormProps) => {
           label="Fecha de Fin"
           minDate={new Date(new Date().setDate(new Date().getDate() + 1))}
         />
-        <RHFInput name="shared_user_id" label="Usuario Compartido" />
 
         <div className="flex space-x-2">
           <Button onClick={onCancel} type="button" variant={"secondary"}>


### PR DESCRIPTION
This pull request removes the `shared_user_id` field and related functionality from both the budgets and goals features. The changes simplify the data models, forms, and UI components by eliminating support for shared users.

### Removal of `shared_user_id` in Budgets:

* [`src/features/budgets/interfaces/budgets.interface.ts`](diffhunk://#diff-0fb11e6b961cc70545dc962d25c29dff20ef47f790e6e71834ba2edeebc54dcbL4): Removed the `shared_user_id` field from the `BudgetBase` and `BudgetCreate` interfaces. [[1]](diffhunk://#diff-0fb11e6b961cc70545dc962d25c29dff20ef47f790e6e71834ba2edeebc54dcbL4) [[2]](diffhunk://#diff-0fb11e6b961cc70545dc962d25c29dff20ef47f790e6e71834ba2edeebc54dcbL18)
* [`src/features/budgets/hooks/use-budget-form.ts`](diffhunk://#diff-0853cd8320c1faff37df1289745b8ac29d8906d7f189d754a0b20ca55300cb6eL13): Removed `shared_user_id` from the budget schema and default values in the `useBudgetForm` hook. [[1]](diffhunk://#diff-0853cd8320c1faff37df1289745b8ac29d8906d7f189d754a0b20ca55300cb6eL13) [[2]](diffhunk://#diff-0853cd8320c1faff37df1289745b8ac29d8906d7f189d754a0b20ca55300cb6eL58)
* [`src/features/budgets/presentation/components/budget-card.tsx`](diffhunk://#diff-3fd983b58b1d2145f6007b9aa1c989b443dca0e7d608c651e8a31e5503269821L96-L101): Removed the UI display for shared user information in the `BudgetCard` component.
* [`src/features/budgets/presentation/components/budget-form.tsx`](diffhunk://#diff-33b9f08d68385e0f698a5223c36856854587bd623d04acf2f8777d5f274ec8adL51-L56): Removed the input field for `shared_user_id` in the `BudgetForm` component.

### Removal of `shared_user_id` in Goals:

* [`src/features/goals/interfaces/goals.interface.ts`](diffhunk://#diff-33498bfc4a01941a8a78c7d7cfb7cf9e7abe72a2f68f9c8967c0305b353c78acL4): Removed the `shared_user_id` field from the `GoalBase` interface.
* [`src/features/goals/hooks/use-goal-form.ts`](diffhunk://#diff-e473df00dc1daed995e9477b799c9a399398233d32606f8c43ae9b2f3787c74fL11): Removed `shared_user_id` from the goal schema and default values in the `useGoalForm` hook. [[1]](diffhunk://#diff-e473df00dc1daed995e9477b799c9a399398233d32606f8c43ae9b2f3787c74fL11) [[2]](diffhunk://#diff-e473df00dc1daed995e9477b799c9a399398233d32606f8c43ae9b2f3787c74fL55)
* [`src/features/goals/presentation/components/goal-card.tsx`](diffhunk://#diff-d9258deea567231b9d0a3713d838980c386e51884124b95b75b4278b3419e89fL73-L78): Removed the UI display for shared user information in the `GoalCard` component.
* [`src/features/goals/presentation/components/goal-form.tsx`](diffhunk://#diff-8d62b8c67ebc24495e1753185a9dc1bcc26615dd5349306a53862a29d53acc07L57): Removed the input field for `shared_user_id` in the `GoalForm` component.